### PR TITLE
Add theme toggle with persistence

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,19 @@
+:root {
+  --bg-color: #fff;
+  --text-color: #000;
+}
+
+.dark {
+  --bg-color: #222;
+  --text-color: #fff;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
+
 .App {
   text-align: center;
   padding: 20px;
@@ -23,4 +39,10 @@
 
 .no-result {
   color: #888;
+}
+
+.theme-toggle {
+  margin-bottom: 20px;
+  padding: 6px 12px;
+  cursor: pointer;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, createContext } from 'react';
 import dataA from './data/donation_a.json';
 import dataB from './data/donation_b.json';
 import dataC from './data/donation_c.json';
@@ -6,10 +6,25 @@ import dataD from './data/donation_d.json';
 import dataE from './data/donation_e.json';
 import './App.css';
 
+export const ThemeContext = createContext();
+
 const allData = [...dataA, ...dataB, ...dataC, ...dataD, ...dataE];
 
 function App() {
   const [query, setQuery] = useState('');
+  const [theme, setTheme] = useState(() =>
+    localStorage.getItem('theme') || 'light'
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
 
   const results = useMemo(() => {
     if (!query) return [];
@@ -24,8 +39,12 @@ function App() {
   }, [query]);
 
   return (
-    <div className="App">
-      <h1>헌혈 제한 조건 검색</h1>
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <div className="App">
+        <h1>헌혈 제한 조건 검색</h1>
+        <button onClick={toggleTheme} className="theme-toggle">
+          테마 토글
+        </button>
       <input
         className="search-input"
         type="text"
@@ -42,8 +61,9 @@ function App() {
         {query && results.length === 0 && (
           <li className="no-result">검색 결과가 없습니다.</li>
         )}
-      </ul>
-    </div>
+        </ul>
+      </div>
+    </ThemeContext.Provider>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,3 +10,14 @@ test('검색어 입력 시 해당 제한 조건이 표시된다', async () => {
     screen.getByText(/감염 이력 있는 경우 영구 헌혈 금지/i)
   ).toBeInTheDocument();
 });
+
+test('테마 토글 버튼 클릭 시 document 클래스가 변경된다', async () => {
+  localStorage.clear();
+  render(<App />);
+  const button = screen.getByRole('button', { name: /테마 토글/i });
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  await userEvent.click(button);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+  await userEvent.click(button);
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+});

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 code {


### PR DESCRIPTION
## Summary
- manage light/dark theme in `App.js`
- provide toggle button and context
- style light and dark mode via CSS variables
- persist theme to `localStorage`
- test theme toggle button

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688337e1a580832ba870ac0d0493096d