### PR TITLE
Fix: Remove unused variables to fix build failure

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useContext } from 'react';
+import { useState, useMemo, useContext } from 'react';
 import { FiSearch, FiSun, FiMoon } from 'react-icons/fi';
 import {
   TextField,
@@ -7,7 +7,6 @@ import {
   ToggleButtonGroup,
   FormControl,
   InputLabel,
-  Tooltip,
 } from '@mui/material';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { lightTheme, darkTheme } from './theme';

--- a/src/components/ResultItem.js
+++ b/src/components/ResultItem.js
@@ -22,7 +22,6 @@ const ResultItem = ({ item, baseDate, formatDate }) => {
     restrictionType,
     condition,
     name,
-    type,
     description,
     matchInfo,
     allowable,


### PR DESCRIPTION
- Removed unused `useEffect` and `Tooltip` imports from `App.js`.
- Removed unused `type` variable from `ResultItem.js`.