### PR TITLE
feat: Improve pagination UI to Material Design 3 style

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -258,13 +258,15 @@ function App() {
           totalResultsCount={results.length}
         />
 
-        {results.length > ITEMS_PER_PAGE && (
-          <Pagination
-            totalPages={Math.ceil(results.length / ITEMS_PER_PAGE)}
-            currentPage={currentPage}
-            onPageChange={setCurrentPage}
-          />
-        )}
+        <div className="mt-8">
+          {results.length > ITEMS_PER_PAGE && (
+            <Pagination
+              totalPages={Math.ceil(results.length / ITEMS_PER_PAGE)}
+              currentPage={currentPage}
+              onPageChange={setCurrentPage}
+            />
+          )}
+        </div>
 
         <footer className="text-center text-sm text-gray-500 mt-8 py-4 border-t">
           <p>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -14,7 +14,7 @@ const Pagination = ({
 
   return (
     <div className="flex justify-center mt-4">
-      <ButtonGroup variant="contained" aria-label="outlined primary button group">
+      <ButtonGroup variant="text" aria-label="outlined primary button group">
         <Button disabled={currentPage === 1} onClick={() => onPageChange(currentPage - 1)}>
           이전
         </Button>
@@ -22,7 +22,7 @@ const Pagination = ({
           <Button
             key={number}
             onClick={() => onPageChange(number)}
-            disabled={currentPage === number}
+            variant={currentPage === number ? "contained" : "text"}
           >
             {number}
           </Button>


### PR DESCRIPTION
- Changed the ButtonGroup variant to 'text' for a lighter look.
- Highlighted the current page button with the 'contained' variant.
- Added margin-top to the pagination component for better visual separation from the result list.